### PR TITLE
Changed identity comparisons ("is 0") to equality ("== 0") due to hav…

### DIFF
--- a/scte/Scte35/SpliceDescriptor.py
+++ b/scte/Scte35/SpliceDescriptor.py
@@ -27,16 +27,16 @@ class SpliceDescriptor:
         new_descriptor["descriptor_length"] = bitarray_data.read("uint:8")
         
         new_descriptor["identifier"] = bitarray_data.read("uint:32")
-        if new_descriptor["splice_descriptor_tag"] is 0:
+        if new_descriptor["splice_descriptor_tag"] == 0:
             # avail descriptor
             new_descriptor.update(AvailDescriptor(bitarray_data).as_dict)
-        elif new_descriptor["splice_descriptor_tag"] is 1:
+        elif new_descriptor["splice_descriptor_tag"] == 1:
             # DTMF Descriptor
             new_descriptor.update(DTMFDescriptor(bitarray_data).as_dict)
-        elif new_descriptor["splice_descriptor_tag"] is 2:
+        elif new_descriptor["splice_descriptor_tag"] == 2:
             # SegmentationDescriptor
             new_descriptor.update(SegmentationDescriptor(bitarray_data).as_dict)
-        elif new_descriptor["splice_descriptor_tag"] is 3:
+        elif new_descriptor["splice_descriptor_tag"] == 3:
             # Time Descriptor
             None
         self.__obj_dict = new_descriptor

--- a/scte/Scte35/SpliceEvent.py
+++ b/scte/Scte35/SpliceEvent.py
@@ -41,16 +41,16 @@ class SpliceEvent:
             self.splice_info_section = init_dict
 
             # Now, replace simple dict representations with actual objects
-            if init_dict["splice_command_type"] is 0:
+            if init_dict["splice_command_type"] == 0:
                 self.is_splice_null = True
                 self.splice_info_section["splice_null"] = SpliceNull(None)
-            elif init_dict["splice_command_type"] is 4:
+            elif init_dict["splice_command_type"] == 4:
                 self.is_splice_schedule = True
                 self.splice_info_section["splice_schedule"] = SpliceSchedule.from_dict(init_dict["splice_schedule"])
-            elif init_dict["splice_command_type"] is 5:
+            elif init_dict["splice_command_type"] == 5:
                 self.is_splice_insert = True
                 self.splice_info_section["splice_insert"] = SpliceInsert.from_dict(init_dict["splice_insert"])
-            elif init_dict["splice_command_type"] is 6:
+            elif init_dict["splice_command_type"] == 6:
                 self.is_time_signal = True
                 self.splice_info_section["time_signal"] = TimeSignal.from_dict(init_dict["time_signal"])
 
@@ -84,16 +84,16 @@ class SpliceEvent:
         self.splice_info_section["splice_command_type"] = bitarray_data.read("uint:8")
 
         # the pos pointer of bitarray_data will be mutated after the following constructors
-        if self.splice_info_section["splice_command_type"] is 0:
+        if self.splice_info_section["splice_command_type"] == 0:
             self.is_splice_null = True
             self.splice_info_section["splice_null"] = SpliceNull(bitarray_data)
-        elif self.splice_info_section["splice_command_type"] is 4:
+        elif self.splice_info_section["splice_command_type"] == 4:
             self.is_splice_schedule = True
             self.splice_info_section["splice_schedule"] = SpliceSchedule(bitarray_data)
-        elif self.splice_info_section["splice_command_type"] is 5:
+        elif self.splice_info_section["splice_command_type"] == 5:
             self.is_splice_insert = True
             self.splice_info_section["splice_insert"] = SpliceInsert(bitarray_data)
-        elif self.splice_info_section["splice_command_type"] is 6:
+        elif self.splice_info_section["splice_command_type"] == 6:
             self.is_time_signal = True
             self.splice_info_section["time_signal"] = TimeSignal(bitarray_data)
         # Loop length is number of total bytes for descriptors
@@ -131,16 +131,16 @@ class SpliceEvent:
         splice_info_section_begin_bs = bitstring.pack(fmt=self.bitstring_format, **self.splice_info_section)
 
         splice_command_type_bs = None
-        if self.splice_info_section["splice_command_type"] is 0:
+        if self.splice_info_section["splice_command_type"] == 0:
             raise NotImplementedError('Can not interpret splice_null events')
 
-        elif self.splice_info_section["splice_command_type"] is 4:
+        elif self.splice_info_section["splice_command_type"] == 4:
             raise NotImplementedError('Can not interpret splice_schedule events')
 
-        elif self.splice_info_section["splice_command_type"] is 5:
+        elif self.splice_info_section["splice_command_type"] == 5:
             splice_command_type_bs = self.splice_info_section["splice_insert"].serialize()
 
-        elif self.splice_info_section["splice_command_type"] is 6:
+        elif self.splice_info_section["splice_command_type"] == 6:
             splice_command_type_bs = self.splice_info_section["time_signal"].serialize()
 
         descriptor_loop_length_bs = bitstring.pack(fmt='uint:16=descriptor_loop_length', **self.splice_info_section)

--- a/scte/Scte35/scte35_enums.py
+++ b/scte/Scte35/scte35_enums.py
@@ -97,5 +97,5 @@ def get_hex_string(type_id):
 
 def get_id_from_message(message):
     for type_id in __segmentation_type_ids:
-        if __segmentation_type_ids[type_id]["message"] is message:
+        if __segmentation_type_ids[type_id]["message"] == message:
             return type_id


### PR DESCRIPTION
Changed identity comparisons ("is 0") to equality ("== 0") due to have SyntaxWarnings in Python 3.8+.
The original intent is to compare values and not the identity of the object.
I've touched three files where this occurs, especially scte35_enums.get_id_from_message where it complained about comparing to an int literal.
Also, I want to again request a PR to see if you'd accept, since my other PR did not get approved. I'm relying on this library in my production code, so I want to make some adjustments to the module.
The last commit was quite some time ago, so checking in to see if this is still maintained.